### PR TITLE
feat: Member - 금융 API 연동 

### DIFF
--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/config/WebClientConfig.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/config/WebClientConfig.java
@@ -7,7 +7,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Configuration
 public class WebClientConfig {
 
-    private final String BASE_URL = "https://finoppenapi.ssafy.io/ssafy/api/v1";
+    private final String BASE_URL = "https://finopenapi.ssafy.io/ssafy/api/v1";
 
     @Bean
     public WebClient.Builder webClientBuilder() {

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/account/mapper/AccountMapper.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/account/mapper/AccountMapper.java
@@ -15,7 +15,7 @@ import org.springframework.stereotype.Component;
 public class AccountMapper {
     public ShinhanMakeAccountRequest toShinhanMakeAccountRequest(MakeAccountRequest request, Member member) {
         return new ShinhanMakeAccountRequest(
-                new GlobalUserHeader("createDemandDepositAccount",member.getApiKey()),
+                new GlobalUserHeader("createDemandDepositAccount",member.getUserKey()),
                 request.getAccountTypeUniqueNo()
         );
     }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/client/MemberClient.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/client/MemberClient.java
@@ -1,0 +1,43 @@
+package com.shinhan.dongibuyeo.domain.member.client;
+
+import com.shinhan.dongibuyeo.domain.member.dto.client.ShinhanMemberRequest;
+import com.shinhan.dongibuyeo.domain.member.dto.client.ShinhanMemberResponse;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.nio.charset.StandardCharsets;
+
+@Component
+public class MemberClient {
+
+    private final WebClient webClient;
+
+    public MemberClient(WebClient.Builder webClient) {
+        this.webClient = webClient.build();
+    }
+
+    public ShinhanMemberResponse saveMember(ShinhanMemberRequest request) {
+        return webClient.post()
+                .uri("/member/")
+                .accept(MediaType.APPLICATION_JSON)
+                .acceptCharset(StandardCharsets.UTF_8)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(ShinhanMemberResponse.class)
+                .blockOptional()
+                .orElseThrow();
+    }
+
+    public ShinhanMemberResponse searchMember(ShinhanMemberRequest request) {
+        return webClient.post()
+                .uri("/member/search")
+                .accept(MediaType.APPLICATION_JSON)
+                .acceptCharset(StandardCharsets.UTF_8)
+                .bodyValue(request)
+                .retrieve()
+                .bodyToMono(ShinhanMemberResponse.class)
+                .blockOptional()
+                .orElseThrow();
+    }
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/client/MemberClient.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/client/MemberClient.java
@@ -2,6 +2,8 @@ package com.shinhan.dongibuyeo.domain.member.client;
 
 import com.shinhan.dongibuyeo.domain.member.dto.client.ShinhanMemberRequest;
 import com.shinhan.dongibuyeo.domain.member.dto.client.ShinhanMemberResponse;
+import com.shinhan.dongibuyeo.domain.member.exception.MemberConflictException;
+import com.shinhan.dongibuyeo.domain.member.exception.MemberNotFoundException;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
@@ -26,7 +28,7 @@ public class MemberClient {
                 .retrieve()
                 .bodyToMono(ShinhanMemberResponse.class)
                 .blockOptional()
-                .orElseThrow();
+                .orElseThrow(() -> new MemberConflictException(request.getUserId()));
     }
 
     public ShinhanMemberResponse searchMember(ShinhanMemberRequest request) {
@@ -38,6 +40,6 @@ public class MemberClient {
                 .retrieve()
                 .bodyToMono(ShinhanMemberResponse.class)
                 .blockOptional()
-                .orElseThrow();
+                .orElseThrow(MemberNotFoundException::new);
     }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/controller/MemberController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/controller/MemberController.java
@@ -37,7 +37,7 @@ public class MemberController {
     }
 
     @GetMapping("/duplicate/{email}")
-    public ResponseEntity<DuplicateEmailResponse> duplicateNickname(@PathVariable String email) {
+    public ResponseEntity<DuplicateEmailResponse> duplicateEmail(@PathVariable String email) {
         return ResponseEntity.ok(memberService.duplicateEmail(email));
     }
 

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/dto/client/ShinhanMemberRequest.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/dto/client/ShinhanMemberRequest.java
@@ -1,0 +1,13 @@
+package com.shinhan.dongibuyeo.domain.member.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShinhanMemberRequest {
+    private String apiKey;
+    private String userId;
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/dto/client/ShinhanMemberResponse.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/dto/client/ShinhanMemberResponse.java
@@ -1,0 +1,18 @@
+package com.shinhan.dongibuyeo.domain.member.dto.client;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ShinhanMemberResponse {
+
+    private String userId;
+    private String userName;
+    private String institutionCode;
+    private String userKey;
+    private String created;
+    private String modified;
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/dto/response/DuplicateEmailResponse.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/dto/response/DuplicateEmailResponse.java
@@ -9,5 +9,4 @@ import lombok.Getter;
 @AllArgsConstructor
 public class DuplicateEmailResponse {
     private Boolean isPresent;
-    private String apiKey;
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/dto/response/MemberResponse.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/dto/response/MemberResponse.java
@@ -16,7 +16,7 @@ public class MemberResponse {
     private String name;
     private String nickname;
     private String profileImage;
-    private String apiKey;
+    private String userKey;
     private String deviceToken;
 
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/entity/Member.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/entity/Member.java
@@ -2,8 +2,10 @@ package com.shinhan.dongibuyeo.domain.member.entity;
 
 import com.github.f4b6a3.ulid.UlidCreator;
 import com.shinhan.dongibuyeo.domain.account.entity.Account;
+import com.shinhan.dongibuyeo.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.SQLRestriction;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,7 +15,8 @@ import java.util.UUID;
 @Getter
 @EqualsAndHashCode(of = "nickname")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+@SQLRestriction("deleted_at is null")
+public class Member extends BaseEntity {
 
     @Id
     @Column(columnDefinition = "BINARY(16)")
@@ -30,7 +33,7 @@ public class Member {
 
     private String profileImage;
 
-    private String apiKey;
+    private String userKey;
 
     private String deviceToken;
 
@@ -49,8 +52,8 @@ public class Member {
         this.deviceToken = deviceToken;
     }
 
-    public void updateApiKey(String apiKey) {
-        this.apiKey = apiKey;
+    public void updateUserKey(String userKey) {
+        this.userKey = userKey;
     }
 
     public void updateDeviceToken(String deviceToken) {

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/exception/MemberConflictException.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/exception/MemberConflictException.java
@@ -1,0 +1,19 @@
+package com.shinhan.dongibuyeo.domain.member.exception;
+
+import com.shinhan.dongibuyeo.global.exception.ConflictException;
+import com.shinhan.dongibuyeo.global.exception.NotFoundException;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class MemberConflictException extends ConflictException {
+
+    public MemberConflictException(String email) {
+        super(
+                "CONFLICT_MEMBER_01",
+                "이미 존재하는 회원입니다.",
+                Map.of("memberId", String.valueOf(email))
+        );
+    }
+
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/exception/MemberNotFoundException.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/exception/MemberNotFoundException.java
@@ -7,9 +7,16 @@ import java.util.UUID;
 
 public class MemberNotFoundException extends NotFoundException {
 
-    public MemberNotFoundException(UUID memberId) {
+    public MemberNotFoundException() {
         super(
                 "NOT_FOUND_MEMBER_01",
+                "아이디에 부합한 회원을 찾을 수 없습니다."
+        );
+    }
+
+    public MemberNotFoundException(UUID memberId) {
+        super(
+                "NOT_FOUND_MEMBER_02",
                 "아이디에 부합한 회원을 찾을 수 없습니다.",
                 Map.of("memberId", String.valueOf(memberId))
         );
@@ -17,7 +24,7 @@ public class MemberNotFoundException extends NotFoundException {
 
     public MemberNotFoundException(String email) {
         super(
-                "NOT_FOUND_MEMBER_02",
+                "NOT_FOUND_MEMBER_03",
                 "이메일에 부합한 회원을 찾을 수 없습니다.",
                 Map.of("memberId", String.valueOf(email))
         );


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #1

## 📝작업 내용

> userKey 생성, 이메일 기반 유저 조회 부분 금융 API와 연동 완료
> Member의 필드명 apiKey -> userKey 로 변경

## 💬리뷰 요구사항

> MemberController의 end-point 네이밍, userKey 중복 검사 및 등록 로직 한번 봐주시면 감사하겠습니다