### PR TITLE
feat: Challenge API 구현

### DIFF
--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/account/mapper/AccountMapper.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/account/mapper/AccountMapper.java
@@ -13,9 +13,9 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class AccountMapper {
-    public ShinhanMakeAccountRequest toShinhanMakeAccountRequest(MakeAccountRequest request,String apiKey, Member member) {
+    public ShinhanMakeAccountRequest toShinhanMakeAccountRequest(MakeAccountRequest request, String apiKey, Member member) {
         return new ShinhanMakeAccountRequest(
-                new GlobalUserHeader("createDemandDepositAccount",apiKey,member.getUserKey()),
+                new GlobalUserHeader("createDemandDepositAccount", apiKey, member.getUserKey()),
                 request.getAccountTypeUniqueNo()
         );
     }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/account/service/AccountService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/account/service/AccountService.java
@@ -9,11 +9,9 @@ import com.shinhan.dongibuyeo.domain.account.mapper.AccountMapper;
 import com.shinhan.dongibuyeo.domain.account.repository.AccountRepository;
 import com.shinhan.dongibuyeo.domain.member.entity.Member;
 import com.shinhan.dongibuyeo.domain.member.service.MemberService;
-import com.shinhan.dongibuyeo.global.header.GlobalUserHeader;
 import jakarta.transaction.Transactional;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.reactive.function.client.WebClient;
 
 import java.util.UUID;
 
@@ -41,17 +39,21 @@ public class AccountService {
     @Transactional
     public AccountResponse makePersonalAccount(MakeAccountRequest request) {
         Member member = memberService.getMemberById(request.getMemberId());
-        ShinhanMakeAccountResponse shinhanAccount = accountClient.makeAccount(accountMapper.toShinhanMakeAccountRequest(request,apiKey,member));
+        ShinhanMakeAccountResponse shinhanAccount = accountClient.makeAccount(accountMapper.toShinhanMakeAccountRequest(request, apiKey, member));
         Account account = accountRepository.save(accountMapper.toAccountEntity(shinhanAccount));
         account.updateMember(member);
         return accountMapper.toAccountResponse(account);
     }
 
-    public void makeChallengeAccount() {}
+    public void makeChallengeAccount() {
+    }
 
-    public void getAllAccountsByMemberId(UUID memberId) {}
+    public void getAllAccountsByMemberId(UUID memberId) {
+    }
 
-    public void getAccountByAccountId(UUID accountId) {}
+    public void getAccountByAccountId(UUID accountId) {
+    }
 
-    public void terminateAccountByMemberId() {}
+    public void terminateAccountByMemberId() {
+    }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/account/service/AccountService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/account/service/AccountService.java
@@ -11,6 +11,7 @@ import com.shinhan.dongibuyeo.domain.member.entity.Member;
 import com.shinhan.dongibuyeo.domain.member.service.MemberService;
 import com.shinhan.dongibuyeo.global.header.GlobalUserHeader;
 import jakarta.transaction.Transactional;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.reactive.function.client.WebClient;
 
@@ -18,6 +19,9 @@ import java.util.UUID;
 
 @Service
 public class AccountService {
+
+    @Value("${shinhan.key}")
+    private String apiKey;
 
     private final AccountRepository accountRepository;
 
@@ -37,8 +41,9 @@ public class AccountService {
     @Transactional
     public AccountResponse makePersonalAccount(MakeAccountRequest request) {
         Member member = memberService.getMemberById(request.getMemberId());
-        ShinhanMakeAccountResponse shinhanAccount = accountClient.makeAccount(accountMapper.toShinhanMakeAccountRequest(request,member));
-        Account account = accountRepository.save(accountMapper.toAccountEntity(shinhanAccount,member));
+        ShinhanMakeAccountResponse shinhanAccount = accountClient.makeAccount(accountMapper.toShinhanMakeAccountRequest(request,apiKey,member));
+        Account account = accountRepository.save(accountMapper.toAccountEntity(shinhanAccount));
+        account.updateMember(member);
         return accountMapper.toAccountResponse(account);
     }
 

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -4,8 +4,8 @@ import com.shinhan.dongibuyeo.domain.challenge.dto.request.CancelJoinChallengeRe
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
+import com.shinhan.dongibuyeo.domain.challenge.dto.response.MemberChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.service.ChallengeService;
-import com.shinhan.dongibuyeo.domain.member.dto.response.MemberResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -56,8 +56,13 @@ public class ChallengeController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/members/{memberId}")
-    public ResponseEntity<List<ChallengeResponse>> getMemberChallenges(@PathVariable UUID memberId) {
+    @GetMapping("/member")
+    public ResponseEntity<List<ChallengeResponse>> getMemberChallenges(@RequestParam UUID memberId) {
         return ResponseEntity.ok(challengeService.findAllChallengesByMemberId(memberId));
+    }
+
+    @GetMapping("/member/{challengeId}")
+    public ResponseEntity<MemberChallengeResponse> getMemberChallengeByChallengeId(@PathVariable UUID challengeId, @RequestParam UUID memberId) {
+        return ResponseEntity.ok(challengeService.findChallengeByChallengeIdAndMemberId(challengeId, memberId));
     }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -1,5 +1,6 @@
 package com.shinhan.dongibuyeo.domain.challenge.controller;
 
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.CancelJoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
@@ -42,9 +43,15 @@ public class ChallengeController {
         return ResponseEntity.ok(challengeService.makeChallenge(request));
     }
 
-    @PostMapping("/join")
-    public ResponseEntity<Void> joinChallenge(@RequestBody @Valid JoinChallengeRequest request) {
-        challengeService.joinChallenge(request);
+    @PostMapping("/{challengeId}/join")
+    public ResponseEntity<Void> joinChallenge(@PathVariable UUID challengeId, @RequestBody @Valid JoinChallengeRequest request) {
+        challengeService.joinChallenge(challengeId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/{challengeId}/cancel")
+    public ResponseEntity<Void> cancelJoinChallenge(@PathVariable UUID challengeId, @RequestBody @Valid CancelJoinChallengeRequest request) {
+        challengeService.cancelJoinChallenge(challengeId, request.getMemberId());
         return ResponseEntity.ok().build();
     }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -1,0 +1,14 @@
+package com.shinhan.dongibuyeo.domain.challenge.controller;
+
+import com.shinhan.dongibuyeo.domain.challenge.service.ChallengeService;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class ChallengeController {
+
+    private final ChallengeService challengeService;
+
+    public ChallengeController(final ChallengeService challengeService) {
+        this.challengeService = challengeService;
+    }
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -1,10 +1,13 @@
 package com.shinhan.dongibuyeo.domain.challenge.controller;
 
+import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.service.ChallengeService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/challenges")
@@ -14,6 +17,11 @@ public class ChallengeController {
 
     public ChallengeController(final ChallengeService challengeService) {
         this.challengeService = challengeService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ChallengeResponse>> getChallenges() {
+        return ResponseEntity.ok(challengeService.findAllChallenges());
     }
 
 

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -4,10 +4,12 @@ import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.service.ChallengeService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/challenges")
@@ -22,6 +24,11 @@ public class ChallengeController {
     @GetMapping
     public ResponseEntity<List<ChallengeResponse>> getChallenges() {
         return ResponseEntity.ok(challengeService.findAllChallenges());
+    }
+
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<ChallengeResponse> getChallengeById(@PathVariable UUID challengeId) {
+        return ResponseEntity.ok(challengeService.findChallengeByChallengeId(challengeId));
     }
 
 

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -5,6 +5,7 @@ import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.service.ChallengeService;
+import com.shinhan.dongibuyeo.domain.member.dto.response.MemberResponse;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -53,5 +54,10 @@ public class ChallengeController {
     public ResponseEntity<Void> cancelJoinChallenge(@PathVariable UUID challengeId, @RequestBody @Valid CancelJoinChallengeRequest request) {
         challengeService.cancelJoinChallenge(challengeId, request.getMemberId());
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/members/{memberId}")
+    public ResponseEntity<List<ChallengeResponse>> getMemberChallenges(@PathVariable UUID memberId) {
+        return ResponseEntity.ok(challengeService.findAllChallengesByMemberId(memberId));
     }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -6,6 +6,7 @@ import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.MemberChallengeResponse;
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
 import com.shinhan.dongibuyeo.domain.challenge.service.ChallengeService;
 import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
@@ -32,6 +33,23 @@ public class ChallengeController {
     @GetMapping("/{challengeId}")
     public ResponseEntity<ChallengeResponse> getChallengeById(@PathVariable UUID challengeId) {
         return ResponseEntity.ok(challengeService.findChallengeByChallengeId(challengeId));
+    }
+
+    @GetMapping("/status")
+    public ResponseEntity<List<ChallengeResponse>> getChallengeByStatus(@RequestParam ChallengeStatus status) {
+        return ResponseEntity.ok(challengeService.findAllChallengesByStatus(status));
+
+    }
+
+    @GetMapping("/member")
+    public ResponseEntity<List<ChallengeResponse>> getMemberChallenges(@RequestParam UUID memberId) {
+        return ResponseEntity.ok(challengeService.findAllChallengesByMemberId(memberId));
+    }
+
+    @GetMapping("/member/{challengeId}")
+    public ResponseEntity<MemberChallengeResponse> getMemberChallengeByChallengeId(@PathVariable UUID challengeId,
+                                                                                   @RequestParam UUID memberId) {
+        return ResponseEntity.ok(challengeService.findChallengeByChallengeIdAndMemberId(challengeId, memberId));
     }
 
     @DeleteMapping("/{challengeId}")
@@ -65,14 +83,4 @@ public class ChallengeController {
         return ResponseEntity.ok().build();
     }
 
-    @GetMapping("/member")
-    public ResponseEntity<List<ChallengeResponse>> getMemberChallenges(@RequestParam UUID memberId) {
-        return ResponseEntity.ok(challengeService.findAllChallengesByMemberId(memberId));
-    }
-
-    @GetMapping("/member/{challengeId}")
-    public ResponseEntity<MemberChallengeResponse> getMemberChallengeByChallengeId(@PathVariable UUID challengeId,
-                                                                                   @RequestParam UUID memberId) {
-        return ResponseEntity.ok(challengeService.findChallengeByChallengeIdAndMemberId(challengeId, memberId));
-    }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -1,6 +1,7 @@
 package com.shinhan.dongibuyeo.domain.challenge.controller;
 
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.CancelJoinChallengeRequest;
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeModifyRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
@@ -39,19 +40,27 @@ public class ChallengeController {
         return ResponseEntity.ok().build();
     }
 
+    @PatchMapping("/{challengeId}")
+    public ResponseEntity<ChallengeResponse> modifyChallengeById(@PathVariable UUID challengeId,
+                                                                 @RequestBody @Valid ChallengeModifyRequest request) {
+        return ResponseEntity.ok(challengeService.updateChallengeByChallengeId(challengeId, request));
+    }
+
     @PostMapping
     public ResponseEntity<ChallengeResponse> makeChallenge(@RequestBody @Valid ChallengeRequest request) {
         return ResponseEntity.ok(challengeService.makeChallenge(request));
     }
 
     @PostMapping("/{challengeId}/join")
-    public ResponseEntity<Void> joinChallenge(@PathVariable UUID challengeId, @RequestBody @Valid JoinChallengeRequest request) {
+    public ResponseEntity<Void> joinChallenge(@PathVariable UUID challengeId,
+                                              @RequestBody @Valid JoinChallengeRequest request) {
         challengeService.joinChallenge(challengeId, request);
         return ResponseEntity.ok().build();
     }
 
     @PostMapping("/{challengeId}/cancel")
-    public ResponseEntity<Void> cancelJoinChallenge(@PathVariable UUID challengeId, @RequestBody @Valid CancelJoinChallengeRequest request) {
+    public ResponseEntity<Void> cancelJoinChallenge(@PathVariable UUID challengeId,
+                                                    @RequestBody @Valid CancelJoinChallengeRequest request) {
         challengeService.cancelJoinChallenge(challengeId, request.getMemberId());
         return ResponseEntity.ok().build();
     }
@@ -62,7 +71,8 @@ public class ChallengeController {
     }
 
     @GetMapping("/member/{challengeId}")
-    public ResponseEntity<MemberChallengeResponse> getMemberChallengeByChallengeId(@PathVariable UUID challengeId, @RequestParam UUID memberId) {
+    public ResponseEntity<MemberChallengeResponse> getMemberChallengeByChallengeId(@PathVariable UUID challengeId,
+                                                                                   @RequestParam UUID memberId) {
         return ResponseEntity.ok(challengeService.findChallengeByChallengeIdAndMemberId(challengeId, memberId));
     }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -1,11 +1,8 @@
 package com.shinhan.dongibuyeo.domain.challenge.controller;
 
-import com.shinhan.dongibuyeo.domain.challenge.dto.request.CancelJoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeModifyRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
-import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
-import com.shinhan.dongibuyeo.domain.challenge.dto.response.MemberChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
 import com.shinhan.dongibuyeo.domain.challenge.service.ChallengeService;
 import jakarta.validation.Valid;
@@ -25,6 +22,11 @@ public class ChallengeController {
         this.challengeService = challengeService;
     }
 
+    @PostMapping
+    public ResponseEntity<ChallengeResponse> makeChallenge(@RequestBody @Valid ChallengeRequest request) {
+        return ResponseEntity.ok(challengeService.makeChallenge(request));
+    }
+
     @GetMapping
     public ResponseEntity<List<ChallengeResponse>> getChallenges() {
         return ResponseEntity.ok(challengeService.findAllChallenges());
@@ -41,22 +43,6 @@ public class ChallengeController {
 
     }
 
-    @GetMapping("/member")
-    public ResponseEntity<List<ChallengeResponse>> getMemberChallenges(@RequestParam UUID memberId) {
-        return ResponseEntity.ok(challengeService.findAllChallengesByMemberId(memberId));
-    }
-
-     @GetMapping("/member/status")
-    public ResponseEntity<List<ChallengeResponse>> getMemberChallengesByStatus(@RequestParam UUID memberId, @RequestParam ChallengeStatus status) {
-        return ResponseEntity.ok(challengeService.findAllChallengesByMemberIdAndStatus(memberId, status));
-    }
-
-    @GetMapping("/member/{challengeId}")
-    public ResponseEntity<MemberChallengeResponse> getMemberChallengeByChallengeId(@PathVariable UUID challengeId,
-                                                                                   @RequestParam UUID memberId) {
-        return ResponseEntity.ok(challengeService.findChallengeByChallengeIdAndMemberId(challengeId, memberId));
-    }
-
     @DeleteMapping("/{challengeId}")
     public ResponseEntity<ChallengeResponse> deleteChallengeById(@PathVariable UUID challengeId) {
         challengeService.deleteChallengeByChallengeId(challengeId);
@@ -65,27 +51,8 @@ public class ChallengeController {
 
     @PatchMapping("/{challengeId}")
     public ResponseEntity<ChallengeResponse> modifyChallengeById(@PathVariable UUID challengeId,
-                                                                 @RequestBody @Valid ChallengeModifyRequest request) {
+                                                                 @RequestBody @Valid ChallengeRequest request) {
         return ResponseEntity.ok(challengeService.updateChallengeByChallengeId(challengeId, request));
-    }
-
-    @PostMapping
-    public ResponseEntity<ChallengeResponse> makeChallenge(@RequestBody @Valid ChallengeRequest request) {
-        return ResponseEntity.ok(challengeService.makeChallenge(request));
-    }
-
-    @PostMapping("/{challengeId}/join")
-    public ResponseEntity<Void> joinChallenge(@PathVariable UUID challengeId,
-                                              @RequestBody @Valid JoinChallengeRequest request) {
-        challengeService.joinChallenge(challengeId, request);
-        return ResponseEntity.ok().build();
-    }
-
-    @PostMapping("/{challengeId}/cancel")
-    public ResponseEntity<Void> cancelJoinChallenge(@PathVariable UUID challengeId,
-                                                    @RequestBody @Valid CancelJoinChallengeRequest request) {
-        challengeService.cancelJoinChallenge(challengeId, request.getMemberId());
-        return ResponseEntity.ok().build();
     }
 
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -31,6 +31,12 @@ public class ChallengeController {
         return ResponseEntity.ok(challengeService.findChallengeByChallengeId(challengeId));
     }
 
+    @DeleteMapping("/{challengeId}")
+    public ResponseEntity<ChallengeResponse> deleteChallengeById(@PathVariable UUID challengeId) {
+        challengeService.deleteChallengeByChallengeId(challengeId);
+        return ResponseEntity.ok().build();
+    }
+
     @PostMapping
     public ResponseEntity<ChallengeResponse> makeChallenge(@RequestBody @Valid ChallengeRequest request) {
         return ResponseEntity.ok(challengeService.makeChallenge(request));

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -46,6 +46,11 @@ public class ChallengeController {
         return ResponseEntity.ok(challengeService.findAllChallengesByMemberId(memberId));
     }
 
+     @GetMapping("/member/status")
+    public ResponseEntity<List<ChallengeResponse>> getMemberChallengesByStatus(@RequestParam UUID memberId, @RequestParam ChallengeStatus status) {
+        return ResponseEntity.ok(challengeService.findAllChallengesByMemberIdAndStatus(memberId, status));
+    }
+
     @GetMapping("/member/{challengeId}")
     public ResponseEntity<MemberChallengeResponse> getMemberChallengeByChallengeId(@PathVariable UUID challengeId,
                                                                                    @RequestParam UUID memberId) {

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/ChallengeController.java
@@ -1,12 +1,12 @@
 package com.shinhan.dongibuyeo.domain.challenge.controller;
 
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.service.ChallengeService;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.UUID;
@@ -31,5 +31,14 @@ public class ChallengeController {
         return ResponseEntity.ok(challengeService.findChallengeByChallengeId(challengeId));
     }
 
+    @PostMapping
+    public ResponseEntity<ChallengeResponse> makeChallenge(@RequestBody @Valid ChallengeRequest request) {
+        return ResponseEntity.ok(challengeService.makeChallenge(request));
+    }
 
+    @PostMapping("/join")
+    public ResponseEntity<Void> joinChallenge(@RequestBody @Valid JoinChallengeRequest request) {
+        challengeService.joinChallenge(request);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/MemberChallengeController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/controller/MemberChallengeController.java
@@ -1,0 +1,59 @@
+package com.shinhan.dongibuyeo.domain.challenge.controller;
+
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.MemberChallengeRequest;
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
+import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
+import com.shinhan.dongibuyeo.domain.challenge.dto.response.MemberChallengeResponse;
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
+import com.shinhan.dongibuyeo.domain.challenge.service.ChallengeService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/challenges/member")
+public class MemberChallengeController {
+
+    private final ChallengeService challengeService;
+
+    public MemberChallengeController(final ChallengeService challengeService) {
+        this.challengeService = challengeService;
+    }
+
+    @GetMapping
+    public ResponseEntity<List<ChallengeResponse>> getMemberChallenges(@RequestParam UUID memberId) {
+        return ResponseEntity.ok(challengeService.findAllChallengesByMemberId(memberId));
+    }
+
+     @GetMapping("/status")
+    public ResponseEntity<List<ChallengeResponse>> getMemberChallengesByStatus(@RequestParam UUID memberId, @RequestParam ChallengeStatus status) {
+        return ResponseEntity.ok(challengeService.findAllChallengesByMemberIdAndStatus(memberId, status));
+    }
+
+    @GetMapping("/{challengeId}")
+    public ResponseEntity<MemberChallengeResponse> getMemberChallengeByChallengeId(@PathVariable UUID challengeId,
+                                                                                   @RequestParam UUID memberId) {
+        return ResponseEntity.ok(challengeService.findChallengeByChallengeIdAndMemberId(challengeId, memberId));
+    }
+
+    @PostMapping("/join")
+    public ResponseEntity<Void> joinChallenge(@RequestBody @Valid JoinChallengeRequest request) {
+        challengeService.joinChallenge(request);
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/cancel")
+    public ResponseEntity<Void> cancelJoinChallenge(@RequestBody @Valid MemberChallengeRequest request) {
+        challengeService.cancelJoinChallenge(request.getMemberId(), request.getChallengeId());
+        return ResponseEntity.ok().build();
+    }
+
+    @PostMapping("/withdraw")
+    public ResponseEntity<Void> withdrawChallenge(@RequestBody @Valid MemberChallengeRequest request) {
+        challengeService.withdrawChallenge(request.getChallengeId(), request.getChallengeId());
+        return ResponseEntity.ok().build();
+    }
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/CancelJoinChallengeRequest.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/CancelJoinChallengeRequest.java
@@ -9,8 +9,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class JoinChallengeRequest {
+public class CancelJoinChallengeRequest {
 
     private UUID memberId;
-    private Long deposit;
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/ChallengeModifyRequest.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/ChallengeModifyRequest.java
@@ -2,6 +2,7 @@ package com.shinhan.dongibuyeo.domain.challenge.dto.request;
 
 import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeType;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,7 +12,7 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class ChallengeRequest {
+public class ChallengeModifyRequest {
 
     private ChallengeType type;
     private LocalDate startDate;

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/ChallengeModifyRequest.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/ChallengeModifyRequest.java
@@ -19,4 +19,5 @@ public class ChallengeModifyRequest {
     private LocalDate endDate;
     private String title;
     private String description;
+    private String image;
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/ChallengeRequest.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/ChallengeRequest.java
@@ -1,0 +1,22 @@
+package com.shinhan.dongibuyeo.domain.challenge.dto.request;
+
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ChallengeRequest {
+
+    private ChallengeType type;
+    private UUID accountId;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String title;
+    private String description;
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/ChallengeRequest.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/ChallengeRequest.java
@@ -18,4 +18,5 @@ public class ChallengeRequest {
     private LocalDate endDate;
     private String title;
     private String description;
+    private String image;
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/JoinChallengeRequest.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/JoinChallengeRequest.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 @AllArgsConstructor
 public class JoinChallengeRequest {
 
+    private UUID challengeId;
     private UUID memberId;
     private Long deposit;
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/JoinChallengeRequest.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/JoinChallengeRequest.java
@@ -1,0 +1,17 @@
+package com.shinhan.dongibuyeo.domain.challenge.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class JoinChallengeRequest {
+
+    private UUID challengeId;
+    private UUID memberId;
+    private Long deposit;
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/MemberChallengeRequest.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/request/MemberChallengeRequest.java
@@ -9,7 +9,8 @@ import java.util.UUID;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-public class CancelJoinChallengeRequest {
+public class MemberChallengeRequest {
 
+    private UUID challengeId;
     private UUID memberId;
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/response/ChallengeResponse.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/response/ChallengeResponse.java
@@ -1,5 +1,6 @@
 package com.shinhan.dongibuyeo.domain.challenge.dto.response;
 
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
 import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ public class ChallengeResponse {
 
     private UUID challengeId;
     private ChallengeType type;
+    private ChallengeStatus status;
     private String accountNo;
     private LocalDate startDate;
     private LocalDate endDate;

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/response/ChallengeResponse.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/response/ChallengeResponse.java
@@ -1,0 +1,28 @@
+package com.shinhan.dongibuyeo.domain.challenge.dto.response;
+
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeType;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ChallengeResponse {
+
+    private UUID challengeId;
+    private ChallengeType type;
+    private String accountNo;
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    private String title;
+    private String description;
+
+    private Long deposit;
+    private Integer participants;
+
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/response/MemberChallengeResponse.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/response/MemberChallengeResponse.java
@@ -1,5 +1,6 @@
 package com.shinhan.dongibuyeo.domain.challenge.dto.response;
 
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
 import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeType;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,6 +16,7 @@ public class MemberChallengeResponse {
 
     private UUID challengeId;
     private ChallengeType type;
+    private ChallengeStatus status;
     private String accountNo;
     private LocalDate startDate;
     private LocalDate endDate;

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/response/MemberChallengeResponse.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/dto/response/MemberChallengeResponse.java
@@ -11,7 +11,7 @@ import java.util.UUID;
 @Getter
 @Builder
 @AllArgsConstructor
-public class ChallengeResponse {
+public class MemberChallengeResponse {
 
     private UUID challengeId;
     private ChallengeType type;
@@ -25,4 +25,8 @@ public class ChallengeResponse {
     private Long totalDeposit;
     private Integer participants;
 
+    private Boolean isSuccess;
+    private Long memberDeposit;
+    private Long reward;
+    private Long points;
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 @Entity
 @Getter
@@ -38,7 +39,7 @@ public class Challenge extends BaseEntity {
     private String title;
     private String description;
 
-    private double deposit;
+    private AtomicLong deposit;
 
     private AtomicInteger participants;
 

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -36,6 +36,8 @@ public class Challenge extends BaseEntity {
     private LocalDate startDate;
     private LocalDate endDate;
 
+    private ChallengeStatus status = ChallengeStatus.SCHEDULED;
+
     private String title;
     private String description;
 
@@ -58,6 +60,17 @@ public class Challenge extends BaseEntity {
         participants.decrementAndGet();
     }
 
+    private ChallengeStatus determineStatus() {
+        LocalDate now = LocalDate.now();
+        if (startDate == null || endDate == null || now.isBefore(startDate)) {
+            return ChallengeStatus.SCHEDULED;
+        }
+        if (now.isAfter(this.endDate)) {
+            return ChallengeStatus.COMPLETED;
+        }
+        return ChallengeStatus.IN_PROGRESS;
+    }
+
     public void updateTitle(String title) {
         this.title = title;
     }
@@ -66,12 +79,10 @@ public class Challenge extends BaseEntity {
         this.description = description;
     }
 
-    public void updateStartDate(LocalDate startDate) {
+    public void updateDate(LocalDate startDate, LocalDate endDate) {
         this.startDate = startDate;
-    }
-
-    public void updateEndDate(LocalDate endDate) {
         this.endDate = endDate;
+        this.status = determineStatus();
     }
 
     public void updateChallengeType(ChallengeType type) {

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -1,0 +1,42 @@
+package com.shinhan.dongibuyeo.domain.challenge.entity;
+
+import com.github.f4b6a3.ulid.UlidCreator;
+import com.shinhan.dongibuyeo.domain.account.entity.Account;
+import com.shinhan.dongibuyeo.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at is null")
+public class Challenge extends BaseEntity {
+
+    @Id
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id = UlidCreator.getMonotonicUlid().toUuid();
+
+    @Enumerated(EnumType.STRING)
+    private ChallengeType type;
+
+    @OneToOne
+    private Account account;
+
+    private LocalDate startDate;
+    private LocalDate endDate;
+
+    private String title;
+    private String description;
+
+    private double deposit;
+
+    private AtomicInteger participants;
+
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -10,6 +10,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -27,6 +29,7 @@ public class Challenge extends BaseEntity {
     private ChallengeType type;
 
     @OneToOne
+    @JoinColumn(name = "account_id", unique = true)
     private Account account;
 
     private LocalDate startDate;
@@ -38,5 +41,8 @@ public class Challenge extends BaseEntity {
     private double deposit;
 
     private AtomicInteger participants;
+
+    @OneToMany(mappedBy = "challenge")
+    private List<MemberChallenge> challengeMembers = new ArrayList<>();
 
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -39,9 +39,9 @@ public class Challenge extends BaseEntity {
     private String title;
     private String description;
 
-    private AtomicLong deposit;
+    private AtomicLong deposit = new AtomicLong(0);
 
-    private AtomicInteger participants;
+    private AtomicInteger participants = new AtomicInteger(0);
 
     @OneToMany(mappedBy = "challenge")
     private List<MemberChallenge> challengeMembers = new ArrayList<>();

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -5,6 +5,7 @@ import com.shinhan.dongibuyeo.domain.account.entity.Account;
 import com.shinhan.dongibuyeo.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
@@ -47,6 +48,17 @@ public class Challenge extends BaseEntity {
 
     @OneToMany(mappedBy = "challenge")
     private List<MemberChallenge> challengeMembers = new ArrayList<>();
+
+    @Builder
+    public Challenge(ChallengeType type, Account account, LocalDate startDate, LocalDate endDate, String title, String description) {
+        this.type = type;
+        this.account = account;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.status = determineStatus();
+        this.title = title;
+        this.description = description;
+    }
 
     public void addMember(MemberChallenge memberChallenge) {
         challengeMembers.add(memberChallenge);

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -58,4 +58,23 @@ public class Challenge extends BaseEntity {
         participants.decrementAndGet();
     }
 
+    public void updateTitle(String title) {
+        this.title = title;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updateStartDate(LocalDate startDate) {
+        this.startDate = startDate;
+    }
+
+    public void updateEndDate(LocalDate endDate) {
+        this.endDate = endDate;
+    }
+
+    public void updateChallengeType(ChallengeType type) {
+        this.type = type;
+    }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -46,15 +46,15 @@ public class Challenge extends BaseEntity {
     @OneToMany(mappedBy = "challenge")
     private List<MemberChallenge> challengeMembers = new ArrayList<>();
 
-    public void addMember(MemberChallenge memberChallenge, Long userDeposit) {
+    public void addMember(MemberChallenge memberChallenge) {
         challengeMembers.add(memberChallenge);
-        deposit.getAndAdd(userDeposit);
+        deposit.getAndAdd(memberChallenge.getDeposit());
         participants.incrementAndGet();
     }
 
-    public void removeMember(MemberChallenge memberChallenge, Long userDeposit) {
+    public void removeMember(MemberChallenge memberChallenge) {
         challengeMembers.remove(memberChallenge);
-        deposit.getAndAdd(-userDeposit);
+        deposit.getAndAdd(-memberChallenge.getDeposit());
         participants.decrementAndGet();
     }
 

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -39,7 +39,7 @@ public class Challenge extends BaseEntity {
     private String title;
     private String description;
 
-    private AtomicLong deposit = new AtomicLong(0);
+    private AtomicLong totalDeposit = new AtomicLong(0);
 
     private AtomicInteger participants = new AtomicInteger(0);
 
@@ -48,13 +48,13 @@ public class Challenge extends BaseEntity {
 
     public void addMember(MemberChallenge memberChallenge) {
         challengeMembers.add(memberChallenge);
-        deposit.getAndAdd(memberChallenge.getDeposit());
+        totalDeposit.getAndAdd(memberChallenge.getDeposit());
         participants.incrementAndGet();
     }
 
     public void removeMember(MemberChallenge memberChallenge) {
         challengeMembers.remove(memberChallenge);
-        deposit.getAndAdd(-memberChallenge.getDeposit());
+        totalDeposit.getAndAdd(-memberChallenge.getDeposit());
         participants.decrementAndGet();
     }
 

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -41,6 +41,7 @@ public class Challenge extends BaseEntity {
 
     private String title;
     private String description;
+    private String image;
 
     private AtomicLong totalDeposit = new AtomicLong(0);
 
@@ -50,7 +51,7 @@ public class Challenge extends BaseEntity {
     private List<MemberChallenge> challengeMembers = new ArrayList<>();
 
     @Builder
-    public Challenge(ChallengeType type, Account account, LocalDate startDate, LocalDate endDate, String title, String description) {
+    public Challenge(ChallengeType type, Account account, LocalDate startDate, LocalDate endDate, String title, String description, String image) {
         this.type = type;
         this.account = account;
         this.startDate = startDate;
@@ -58,6 +59,7 @@ public class Challenge extends BaseEntity {
         this.status = determineStatus();
         this.title = title;
         this.description = description;
+        this.image = image;
     }
 
     public void addMember(MemberChallenge memberChallenge) {
@@ -89,6 +91,10 @@ public class Challenge extends BaseEntity {
 
     public void updateDescription(String description) {
         this.description = description;
+    }
+
+    public void updateImage(String image) {
+        this.image = image;
     }
 
     public void updateDate(LocalDate startDate, LocalDate endDate) {

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/Challenge.java
@@ -46,4 +46,16 @@ public class Challenge extends BaseEntity {
     @OneToMany(mappedBy = "challenge")
     private List<MemberChallenge> challengeMembers = new ArrayList<>();
 
+    public void addMember(MemberChallenge memberChallenge, Long userDeposit) {
+        challengeMembers.add(memberChallenge);
+        deposit.getAndAdd(userDeposit);
+        participants.incrementAndGet();
+    }
+
+    public void removeMember(MemberChallenge memberChallenge, Long userDeposit) {
+        challengeMembers.remove(memberChallenge);
+        deposit.getAndAdd(-userDeposit);
+        participants.decrementAndGet();
+    }
+
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/ChallengeStatus.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/ChallengeStatus.java
@@ -1,0 +1,7 @@
+package com.shinhan.dongibuyeo.domain.challenge.entity;
+
+public enum ChallengeStatus {
+    SCHEDULED,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/ChallengeType.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/ChallengeType.java
@@ -1,5 +1,9 @@
 package com.shinhan.dongibuyeo.domain.challenge.entity;
 
 public enum ChallengeType {
-    CONSUMPTION, SAVINGS, QUIZ
+    CONSUMPTION_COFFEE,
+    CONSUMPTION_ALCOHOL,
+    CONSUMPTION_DELIVERY,
+    SAVINGS_777,
+    QUIZ_SOLBEING
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/ChallengeType.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/ChallengeType.java
@@ -2,8 +2,8 @@ package com.shinhan.dongibuyeo.domain.challenge.entity;
 
 public enum ChallengeType {
     CONSUMPTION_COFFEE,
-    CONSUMPTION_ALCOHOL,
+    CONSUMPTION_DRINK,
     CONSUMPTION_DELIVERY,
-    SAVINGS_777,
+    SAVINGS_SEVEN,
     QUIZ_SOLBEING
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/ChallengeType.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/ChallengeType.java
@@ -1,0 +1,5 @@
+package com.shinhan.dongibuyeo.domain.challenge.entity;
+
+public enum ChallengeType {
+    CONSUMPTION, SAVINGS, QUIZ
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/MemberChallenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/MemberChallenge.java
@@ -1,7 +1,6 @@
 package com.shinhan.dongibuyeo.domain.challenge.entity;
 
 import com.github.f4b6a3.ulid.UlidCreator;
-import com.shinhan.dongibuyeo.domain.account.entity.Account;
 import com.shinhan.dongibuyeo.domain.member.entity.Member;
 import com.shinhan.dongibuyeo.global.entity.BaseEntity;
 import jakarta.persistence.*;
@@ -10,9 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
 
-import java.time.LocalDate;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicInteger;
 
 @Entity
 @Getter
@@ -24,10 +21,12 @@ public class MemberChallenge extends BaseEntity {
     @Column(columnDefinition = "BINARY(16)")
     private UUID id = UlidCreator.getMonotonicUlid().toUuid();
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id")
     private Challenge challenge;
 
     private Boolean isSuccess;

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/MemberChallenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/MemberChallenge.java
@@ -5,6 +5,7 @@ import com.shinhan.dongibuyeo.domain.member.entity.Member;
 import com.shinhan.dongibuyeo.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLRestriction;
@@ -37,4 +38,13 @@ public class MemberChallenge extends BaseEntity {
 
     private Long points;
 
+    @Builder
+    public MemberChallenge(Member member, Challenge challenge, Long deposit) {
+        this.member = member;
+        this.challenge = challenge;
+        this.isSuccess = false;
+        this.deposit = deposit;
+        this.reward = 0L;
+        this.points = 0L;
+    }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/MemberChallenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/MemberChallenge.java
@@ -1,0 +1,39 @@
+package com.shinhan.dongibuyeo.domain.challenge.entity;
+
+import com.github.f4b6a3.ulid.UlidCreator;
+import com.shinhan.dongibuyeo.domain.account.entity.Account;
+import com.shinhan.dongibuyeo.domain.member.entity.Member;
+import com.shinhan.dongibuyeo.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
+
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLRestriction("deleted_at is null")
+public class MemberChallenge extends BaseEntity {
+
+    @Id
+    @Column(columnDefinition = "BINARY(16)")
+    private UUID id = UlidCreator.getMonotonicUlid().toUuid();
+
+    @OneToOne
+    private Member member;
+
+    @OneToOne
+    private Challenge challenge;
+
+    private Boolean isSuccess;
+
+    private Double reward;
+
+    private Double points;
+
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/MemberChallenge.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/entity/MemberChallenge.java
@@ -31,8 +31,10 @@ public class MemberChallenge extends BaseEntity {
 
     private Boolean isSuccess;
 
-    private Double reward;
+    private Long deposit;
 
-    private Double points;
+    private Long reward;
+
+    private Long points;
 
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/exception/ChallengeAlreadyStartedException.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/exception/ChallengeAlreadyStartedException.java
@@ -10,7 +10,7 @@ public class ChallengeAlreadyStartedException extends BaseException {
     public ChallengeAlreadyStartedException(UUID challengeId) {
         super(
                 "CHALLENGE_ALREADY_STARTED_01",
-                "이미 챌린지가 시작되어 취소할 수 없습니다.",
+                "이미 시작된 챌린지입니다.",
                 Map.of("challengeId", String.valueOf(challengeId))
         );
     }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/exception/ChallengeAlreadyStartedException.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/exception/ChallengeAlreadyStartedException.java
@@ -1,4 +1,4 @@
-package com.shinhan.dongibuyeo.domain.member.exception;
+package com.shinhan.dongibuyeo.domain.challenge.exception;
 
 import com.shinhan.dongibuyeo.global.exception.BaseException;
 

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/exception/ChallengeCannotWithdrawException.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/exception/ChallengeCannotWithdrawException.java
@@ -1,0 +1,19 @@
+package com.shinhan.dongibuyeo.domain.challenge.exception;
+
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeType;
+import com.shinhan.dongibuyeo.global.exception.BaseException;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class ChallengeCannotWithdrawException extends BaseException {
+
+    public ChallengeCannotWithdrawException(ChallengeType type) {
+        super(
+                "CHALLENGE_CANNOT_WITHDRAW_01",
+                "중도해지가 불가한 챌린지입니다.",
+                Map.of("challengeType", String.valueOf(type))
+        );
+    }
+
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/exception/ChallengeNotFoundException.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/exception/ChallengeNotFoundException.java
@@ -1,0 +1,24 @@
+package com.shinhan.dongibuyeo.domain.challenge.exception;
+
+import com.shinhan.dongibuyeo.global.exception.NotFoundException;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class ChallengeNotFoundException extends NotFoundException {
+
+    public ChallengeNotFoundException() {
+        super(
+                "NOT_FOUND_MEMBER_01",
+                "아이디에 부합한 챌린지를 찾을 수 없습니다."
+        );
+    }
+
+    public ChallengeNotFoundException(UUID challengeId) {
+        super(
+                "NOT_FOUND_MEMBER_02",
+                "아이디에 부합한 챌린지를 찾을 수 없습니다.",
+                Map.of("challengeId", String.valueOf(challengeId))
+        );
+    }
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/exception/MemberChallengeNotFoundException.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/exception/MemberChallengeNotFoundException.java
@@ -1,0 +1,17 @@
+package com.shinhan.dongibuyeo.domain.challenge.exception;
+
+import com.shinhan.dongibuyeo.global.exception.NotFoundException;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class MemberChallengeNotFoundException extends NotFoundException {
+
+    public MemberChallengeNotFoundException(UUID challengeId, UUID memberId) {
+        super(
+                "NOT_FOUND_MEMBER_CHALLENGE_01",
+                "해당 회원에 부합한 챌린지 참여 이력을 찾을 수 없습니다.",
+                Map.of("challengeId", String.valueOf(challengeId), "memberId", String.valueOf(memberId))
+        );
+    }
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/mapper/ChallengeMapper.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/mapper/ChallengeMapper.java
@@ -1,8 +1,7 @@
 package com.shinhan.dongibuyeo.domain.challenge.mapper;
 
-import com.shinhan.dongibuyeo.domain.member.dto.request.MemberSaveRequest;
-import com.shinhan.dongibuyeo.domain.member.dto.response.MemberResponse;
-import com.shinhan.dongibuyeo.domain.member.entity.Member;
+import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
+import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingConstants;
@@ -10,4 +9,9 @@ import org.mapstruct.MappingConstants;
 @Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
 public interface ChallengeMapper {
 
+    @Mapping(source = "challenge.id", target = "challengeId")
+    @Mapping(source = "challenge.account.accountNo", target = "accountNo")
+    @Mapping(target = "deposit", expression = "java(challenge.getDeposit().get())")
+    @Mapping(target = "participants", expression = "java(challenge.getParticipants().get())")
+    ChallengeResponse toChallengeResponse(Challenge challenge);
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/mapper/ChallengeMapper.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/mapper/ChallengeMapper.java
@@ -12,7 +12,7 @@ public interface ChallengeMapper {
 
     @Mapping(source = "challenge.id", target = "challengeId")
     @Mapping(source = "challenge.account.accountNo", target = "accountNo")
-    @Mapping(target = "deposit", expression = "java(challenge.getDeposit().get())")
+    @Mapping(target = "totalDeposit", expression = "java(challenge.getTotalDeposit().get())")
     @Mapping(target = "participants", expression = "java(challenge.getParticipants().get())")
     ChallengeResponse toChallengeResponse(Challenge challenge);
 

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/mapper/ChallengeMapper.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/mapper/ChallengeMapper.java
@@ -1,5 +1,6 @@
 package com.shinhan.dongibuyeo.domain.challenge.mapper;
 
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import org.mapstruct.Mapper;
@@ -14,4 +15,6 @@ public interface ChallengeMapper {
     @Mapping(target = "deposit", expression = "java(challenge.getDeposit().get())")
     @Mapping(target = "participants", expression = "java(challenge.getParticipants().get())")
     ChallengeResponse toChallengeResponse(Challenge challenge);
+
+    Challenge toChallenge(ChallengeRequest challengeRequest);
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/mapper/ChallengeMapper.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/mapper/ChallengeMapper.java
@@ -1,0 +1,13 @@
+package com.shinhan.dongibuyeo.domain.challenge.mapper;
+
+import com.shinhan.dongibuyeo.domain.member.dto.request.MemberSaveRequest;
+import com.shinhan.dongibuyeo.domain.member.dto.response.MemberResponse;
+import com.shinhan.dongibuyeo.domain.member.entity.Member;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+import org.mapstruct.MappingConstants;
+
+@Mapper(componentModel = MappingConstants.ComponentModel.SPRING)
+public interface ChallengeMapper {
+
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/mapper/ChallengeMapper.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/mapper/ChallengeMapper.java
@@ -16,5 +16,5 @@ public interface ChallengeMapper {
     @Mapping(target = "participants", expression = "java(challenge.getParticipants().get())")
     ChallengeResponse toChallengeResponse(Challenge challenge);
 
-    Challenge toChallenge(ChallengeRequest challengeRequest);
+    Challenge toChallengeEntity(ChallengeRequest challengeRequest);
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/ChallengeRepository.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/ChallengeRepository.java
@@ -3,6 +3,10 @@ package com.shinhan.dongibuyeo.domain.challenge.repository;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+import java.util.UUID;
+
 public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
 
+    Optional<Challenge> findChallengeById(UUID challengeId);
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/ChallengeRepository.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/ChallengeRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 import java.util.UUID;
 
-public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+public interface ChallengeRepository extends JpaRepository<Challenge, UUID> {
 
     Optional<Challenge> findChallengeById(UUID challengeId);
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/ChallengeRepository.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/ChallengeRepository.java
@@ -1,12 +1,16 @@
 package com.shinhan.dongibuyeo.domain.challenge.repository;
 
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, UUID> {
 
     Optional<Challenge> findChallengeById(UUID challengeId);
+
+    List<Challenge> findChallengesByStatus(ChallengeStatus status);
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/ChallengeRepository.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/ChallengeRepository.java
@@ -1,8 +1,10 @@
 package com.shinhan.dongibuyeo.domain.challenge.repository;
 
+import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
@@ -13,4 +15,10 @@ public interface ChallengeRepository extends JpaRepository<Challenge, UUID> {
     Optional<Challenge> findChallengeById(UUID challengeId);
 
     List<Challenge> findChallengesByStatus(ChallengeStatus status);
+
+    @Query("SELECT c " +
+            "FROM Challenge c " +
+            "JOIN FETCH c.challengeMembers mc " +
+            "WHERE mc.member.id = :memberId AND c.status = :status")
+    List<ChallengeResponse> findChallengesByMemberIdAndStatus(UUID memberId, ChallengeStatus status);
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/ChallengeRepository.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/ChallengeRepository.java
@@ -1,0 +1,8 @@
+package com.shinhan.dongibuyeo.domain.challenge.repository;
+
+import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, Long> {
+
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/MemberChallengeRepository.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/MemberChallengeRepository.java
@@ -1,0 +1,10 @@
+package com.shinhan.dongibuyeo.domain.challenge.repository;
+
+import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MemberChallengeRepository extends JpaRepository<MemberChallenge, UUID> {
+
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/MemberChallengeRepository.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/MemberChallengeRepository.java
@@ -1,5 +1,6 @@
 package com.shinhan.dongibuyeo.domain.challenge.repository;
 
+import com.shinhan.dongibuyeo.domain.challenge.dto.response.MemberChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
 import org.aspectj.apache.bcel.classfile.LineNumberTable;
@@ -16,8 +17,16 @@ public interface MemberChallengeRepository extends JpaRepository<MemberChallenge
 
     @Query("SELECT c " +
             "FROM Challenge c " +
-            "JOIN MemberChallenge mc " +
+            "JOIN FETCH MemberChallenge mc " +
             "ON mc.challenge.id = c.id " +
             "WHERE mc.member.id = :memberId ")
     Optional<List<Challenge>> findChallengesByMemberId(UUID memberId);
+
+    @Query("SELECT c, mc.isSuccess, mc.deposit memberDeposit, mc.reward, mc.points " +
+            "FROM Challenge c " +
+            "JOIN FETCH MemberChallenge mc " +
+            "ON mc.challenge.id = c.id " +
+            "WHERE mc.member.id = :memberId " +
+            "AND mc.challenge.id = :challengeId")
+    Optional<MemberChallengeResponse> findChallengeByMemberIdAndChallengeId(UUID memberId, UUID challengeId);
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/MemberChallengeRepository.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/MemberChallengeRepository.java
@@ -1,12 +1,23 @@
 package com.shinhan.dongibuyeo.domain.challenge.repository;
 
+import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
+import org.aspectj.apache.bcel.classfile.LineNumberTable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 
 public interface MemberChallengeRepository extends JpaRepository<MemberChallenge, UUID> {
 
     Optional<MemberChallenge> findMemberChallengeByChallengeIdAndMemberId(UUID challengeId, UUID memberId);
+
+    @Query("SELECT c " +
+            "FROM Challenge c " +
+            "JOIN MemberChallenge mc " +
+            "ON mc.challenge.id = c.id " +
+            "WHERE mc.member.id = :memberId ")
+    Optional<List<Challenge>> findChallengesByMemberId(UUID memberId);
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/MemberChallengeRepository.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/MemberChallengeRepository.java
@@ -3,8 +3,10 @@ package com.shinhan.dongibuyeo.domain.challenge.repository;
 import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
 import java.util.UUID;
 
 public interface MemberChallengeRepository extends JpaRepository<MemberChallenge, UUID> {
 
+    Optional<MemberChallenge> findMemberChallengeByChallengeIdAndMemberId(UUID challengeId, UUID memberId);
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/MemberChallengeRepository.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/repository/MemberChallengeRepository.java
@@ -2,6 +2,7 @@ package com.shinhan.dongibuyeo.domain.challenge.repository;
 
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.MemberChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
 import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
 import org.aspectj.apache.bcel.classfile.LineNumberTable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -29,4 +30,5 @@ public interface MemberChallengeRepository extends JpaRepository<MemberChallenge
             "WHERE mc.member.id = :memberId " +
             "AND mc.challenge.id = :challengeId")
     Optional<MemberChallengeResponse> findChallengeByMemberIdAndChallengeId(UUID memberId, UUID challengeId);
+
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -1,6 +1,5 @@
 package com.shinhan.dongibuyeo.domain.challenge.service;
 
-import com.shinhan.dongibuyeo.domain.challenge.dto.request.CancelJoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
@@ -12,12 +11,13 @@ import com.shinhan.dongibuyeo.domain.challenge.mapper.ChallengeMapper;
 import com.shinhan.dongibuyeo.domain.challenge.repository.ChallengeRepository;
 import com.shinhan.dongibuyeo.domain.challenge.repository.MemberChallengeRepository;
 import com.shinhan.dongibuyeo.domain.member.entity.Member;
-import com.shinhan.dongibuyeo.domain.member.exception.ChallengeAlreadyStartedException;
+import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeAlreadyStartedException;
 import com.shinhan.dongibuyeo.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -53,6 +53,14 @@ public class ChallengeService {
 
     public ChallengeResponse findChallengeByChallengeId(UUID challengeId) {
         return challengeMapper.toChallengeResponse(findChallengeById(challengeId));
+    }
+
+    public List<ChallengeResponse> findAllChallengesByMemberId(UUID memberId) {
+        return memberChallengeRepository.findChallengesByMemberId(memberId)
+                .orElseGet(ArrayList::new)
+                .stream()
+                .map(challengeMapper::toChallengeResponse)
+                .toList();
     }
 
     @Transactional
@@ -106,4 +114,5 @@ public class ChallengeService {
         return memberChallengeRepository.findMemberChallengeByChallengeIdAndMemberId(challengeId, memberId)
                 .orElseThrow(() -> new MemberChallengeNotFoundException(challengeId, memberId));
     }
+
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -1,11 +1,13 @@
 package com.shinhan.dongibuyeo.domain.challenge.service;
 
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
+import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeNotFoundException;
 import com.shinhan.dongibuyeo.domain.challenge.mapper.ChallengeMapper;
 import com.shinhan.dongibuyeo.domain.challenge.repository.ChallengeRepository;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.UUID;
 
 @Service
 public class ChallengeService {
@@ -23,5 +25,11 @@ public class ChallengeService {
                 .stream()
                 .map(challengeMapper::toChallengeResponse)
                 .toList();
+    }
+
+    public ChallengeResponse findChallengeByChallengeId(UUID challengeId) {
+        return challengeRepository.findChallengeById(challengeId)
+                .map(challengeMapper::toChallengeResponse)
+                .orElseThrow(() -> new ChallengeNotFoundException(challengeId));
     }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -1,15 +1,14 @@
 package com.shinhan.dongibuyeo.domain.challenge.service;
 
-import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeModifyRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
-import com.shinhan.dongibuyeo.domain.challenge.dto.request.MemberChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.MemberChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
 import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeType;
 import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
+import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeAlreadyStartedException;
 import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeCannotWithdrawException;
 import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeNotFoundException;
 import com.shinhan.dongibuyeo.domain.challenge.exception.MemberChallengeNotFoundException;
@@ -17,7 +16,6 @@ import com.shinhan.dongibuyeo.domain.challenge.mapper.ChallengeMapper;
 import com.shinhan.dongibuyeo.domain.challenge.repository.ChallengeRepository;
 import com.shinhan.dongibuyeo.domain.challenge.repository.MemberChallengeRepository;
 import com.shinhan.dongibuyeo.domain.member.entity.Member;
-import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeAlreadyStartedException;
 import com.shinhan.dongibuyeo.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -1,0 +1,14 @@
+package com.shinhan.dongibuyeo.domain.challenge.service;
+
+import com.shinhan.dongibuyeo.domain.challenge.repository.ChallengeRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ChallengeService {
+
+    private final ChallengeRepository challengeRepository;
+
+    public ChallengeService(ChallengeRepository challengeRepository) {
+        this.challengeRepository = challengeRepository;
+    }
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -90,13 +90,14 @@ public class ChallengeService {
                 .deposit(request.getDeposit())
                 .build();
 
-        memberChallengeRepository.save(memberChallenge);
         // 챌린지 정보 변경
         challenge.addMember(memberChallenge);
+        member.addChallenge(memberChallenge);
     }
 
     @Transactional
     public void cancelJoinChallenge(UUID challengeId, UUID memberId) {
+        Member member = memberService.getMemberById(memberId);
         Challenge challenge = findChallengeById(challengeId);
 
         // TODO: 챌린지 시작 이후엔 취소할 수 없음 -> 적금의 경우 분기처리
@@ -106,6 +107,7 @@ public class ChallengeService {
 
         MemberChallenge memberChallenge = getMemberChallenge(challengeId, memberId);
         challenge.removeMember(memberChallenge);
+        member.removeChallenge(memberChallenge);
         memberChallenge.softDelete();
 
         // TODO: 보증금 반환 로직

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -24,6 +24,11 @@ public class ChallengeService {
         this.challengeMapper = challengeMapper;
     }
 
+    private Challenge findChallengeById(UUID challengeId) {
+        return challengeRepository.findChallengeById(challengeId)
+                .orElseThrow(() -> new ChallengeNotFoundException(challengeId));
+    }
+
     public List<ChallengeResponse> findAllChallenges() {
         return challengeRepository.findAll()
                 .stream()
@@ -32,9 +37,7 @@ public class ChallengeService {
     }
 
     public ChallengeResponse findChallengeByChallengeId(UUID challengeId) {
-        return challengeRepository.findChallengeById(challengeId)
-                .map(challengeMapper::toChallengeResponse)
-                .orElseThrow(() -> new ChallengeNotFoundException(challengeId));
+        return challengeMapper.toChallengeResponse(findChallengeById(challengeId));
     }
 
     @Transactional
@@ -53,4 +56,9 @@ public class ChallengeService {
     }
 
 
+    @Transactional
+    public void deleteChallengeByChallengeId(UUID challengeId) {
+        Challenge challenge = findChallengeById(challengeId);
+        challenge.softDelete();
+    }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -4,9 +4,13 @@ import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
+import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
 import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeNotFoundException;
 import com.shinhan.dongibuyeo.domain.challenge.mapper.ChallengeMapper;
 import com.shinhan.dongibuyeo.domain.challenge.repository.ChallengeRepository;
+import com.shinhan.dongibuyeo.domain.challenge.repository.MemberChallengeRepository;
+import com.shinhan.dongibuyeo.domain.member.entity.Member;
+import com.shinhan.dongibuyeo.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,11 +20,17 @@ import java.util.UUID;
 @Service
 public class ChallengeService {
 
+    private final MemberService memberService;
+
     private final ChallengeRepository challengeRepository;
+    private final MemberChallengeRepository memberChallengeRepository;
+
     private final ChallengeMapper challengeMapper;
 
-    public ChallengeService(ChallengeRepository challengeRepository, ChallengeMapper challengeMapper) {
+    public ChallengeService(MemberService memberService, ChallengeRepository challengeRepository, MemberChallengeRepository memberChallengeRepository, ChallengeMapper challengeMapper) {
+        this.memberService = memberService;
         this.challengeRepository = challengeRepository;
+        this.memberChallengeRepository = memberChallengeRepository;
         this.challengeMapper = challengeMapper;
     }
 
@@ -49,16 +59,26 @@ public class ChallengeService {
     }
 
     @Transactional
-    public void joinChallenge(JoinChallengeRequest request) {
-        // MemberChallenge 생성
-
-        //
-    }
-
-
-    @Transactional
     public void deleteChallengeByChallengeId(UUID challengeId) {
         Challenge challenge = findChallengeById(challengeId);
         challenge.softDelete();
     }
+
+    @Transactional
+    public void joinChallenge(JoinChallengeRequest request) {
+        // MemberChallenge 생성
+        Member member = memberService.getMemberById(request.getMemberId());
+        Challenge challenge = findChallengeById(request.getChallengeId());
+
+        MemberChallenge memberChallenge = MemberChallenge.builder()
+                .member(member)
+                .challenge(challenge)
+                .deposit(request.getDeposit())
+                .build();
+
+        memberChallengeRepository.save(memberChallenge);
+        // 챌린지 정보 변경
+        challenge.addMember(memberChallenge, request.getDeposit());
+    }
+
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -57,6 +57,13 @@ public class ChallengeService {
         return challengeMapper.toChallengeResponse(findChallengeById(challengeId));
     }
 
+    public List<ChallengeResponse> findAllChallengesByStatus(ChallengeStatus status) {
+        return challengeRepository.findChallengesByStatus(status)
+                .stream()
+                .map(challengeMapper::toChallengeResponse)
+                .toList();
+    }
+
     public List<ChallengeResponse> findAllChallengesByMemberId(UUID memberId) {
         return memberChallengeRepository.findChallengesByMemberId(memberId)
                 .orElseGet(ArrayList::new)
@@ -124,6 +131,11 @@ public class ChallengeService {
                 .orElseThrow(() -> new MemberChallengeNotFoundException(challengeId, memberId));
     }
 
+
+    public List<ChallengeResponse> findAllChallengesByMemberIdAndStatus(UUID memberId, ChallengeStatus status) {
+        return challengeRepository.findChallengesByMemberIdAndStatus(memberId, status);
+    }
+
     @Transactional
     public ChallengeResponse updateChallengeByChallengeId(UUID challengeId, ChallengeModifyRequest request) {
         Challenge challenge = findChallengeById(challengeId);
@@ -136,10 +148,4 @@ public class ChallengeService {
         return challengeMapper.toChallengeResponse(challenge);
     }
 
-    public List<ChallengeResponse> findAllChallengesByStatus(ChallengeStatus status) {
-        return challengeRepository.findChallengesByStatus(status)
-                .stream()
-                .map(challengeMapper::toChallengeResponse)
-                .toList();
-    }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -3,11 +3,14 @@ package com.shinhan.dongibuyeo.domain.challenge.service;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeModifyRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.MemberChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.MemberChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeType;
 import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
+import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeCannotWithdrawException;
 import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeNotFoundException;
 import com.shinhan.dongibuyeo.domain.challenge.exception.MemberChallengeNotFoundException;
 import com.shinhan.dongibuyeo.domain.challenge.mapper.ChallengeMapper;
@@ -74,7 +77,7 @@ public class ChallengeService {
 
     @Transactional
     public ChallengeResponse makeChallenge(ChallengeRequest request) {
-        // TODO: request의 계좌 ID 기반으로 계좌를 조회해 계좌 연결하는 로직까지 추가
+        // TODO request의 계좌 ID 기반으로 계좌를 조회해 계좌 연결하는 로직까지 추가
         Challenge challenge = challengeMapper.toChallengeEntity(request);
         challengeRepository.save(challenge);
         return challengeMapper.toChallengeResponse(challenge);
@@ -87,10 +90,15 @@ public class ChallengeService {
     }
 
     @Transactional
-    public void joinChallenge(UUID challengeId, JoinChallengeRequest request) {
+    public void joinChallenge(JoinChallengeRequest request) {
         // MemberChallenge 생성
         Member member = memberService.getMemberById(request.getMemberId());
-        Challenge challenge = findChallengeById(challengeId);
+        Challenge challenge = findChallengeById(request.getChallengeId());
+
+        // 중도 참여 불가
+        if (LocalDate.now().isAfter(challenge.getStartDate())) {
+            throw new ChallengeAlreadyStartedException(challenge.getId());
+        }
 
         MemberChallenge memberChallenge = MemberChallenge.builder()
                 .member(member)
@@ -104,11 +112,11 @@ public class ChallengeService {
     }
 
     @Transactional
-    public void cancelJoinChallenge(UUID challengeId, UUID memberId) {
+    public void cancelJoinChallenge(UUID memberId, UUID challengeId) {
         Member member = memberService.getMemberById(memberId);
         Challenge challenge = findChallengeById(challengeId);
 
-        // TODO: 챌린지 시작 이후엔 취소할 수 없음 -> 적금의 경우 분기처리
+        // 중도 취소 불가
         if (LocalDate.now().isAfter(challenge.getStartDate())) {
             throw new ChallengeAlreadyStartedException(challengeId);
         }
@@ -118,7 +126,30 @@ public class ChallengeService {
         member.removeChallenge(memberChallenge);
         memberChallenge.softDelete();
 
-        // TODO: 보증금 반환 로직
+        // TODO 보증금 반환 로직
+    }
+
+    @Transactional
+    public void withdrawChallenge(UUID challengeId, UUID memberId) {
+        Challenge challenge = findChallengeById(challengeId);
+        Member member = memberService.getMemberById(memberId);
+        MemberChallenge memberChallenge = getMemberChallenge(challengeId, memberId);
+
+        // 적금의 경우만 중도 해지 가능
+        if(challenge.getType() != ChallengeType.SAVINGS) {
+            throw new ChallengeCannotWithdrawException(challenge.getType());
+        }
+
+        // TODO 예치금 조회 후 반환 로직 (챌린지 계좌 -> 유저 챌린지 계좌)
+        Long userDeposit = memberChallenge.getDeposit();
+
+
+        // 챌린지, 참여 이력 수정
+        challenge.removeMember(memberChallenge);
+        member.removeChallenge(memberChallenge);
+        memberChallenge.softDelete();
+
+        // TODO 적금 해지 후 환급 로직 (유저 적금 계좌 -> 유저 챌린지 계좌)
     }
 
     private MemberChallenge getMemberChallenge(UUID challengeId, UUID memberId) {
@@ -131,13 +162,12 @@ public class ChallengeService {
                 .orElseThrow(() -> new MemberChallengeNotFoundException(challengeId, memberId));
     }
 
-
     public List<ChallengeResponse> findAllChallengesByMemberIdAndStatus(UUID memberId, ChallengeStatus status) {
         return challengeRepository.findChallengesByMemberIdAndStatus(memberId, status);
     }
 
     @Transactional
-    public ChallengeResponse updateChallengeByChallengeId(UUID challengeId, ChallengeModifyRequest request) {
+    public ChallengeResponse updateChallengeByChallengeId(UUID challengeId, ChallengeRequest request) {
         Challenge challenge = findChallengeById(challengeId);
 
         challenge.updateChallengeType(request.getType());

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -1,20 +1,25 @@
 package com.shinhan.dongibuyeo.domain.challenge.service;
 
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.CancelJoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
 import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeNotFoundException;
+import com.shinhan.dongibuyeo.domain.challenge.exception.MemberChallengeNotFoundException;
 import com.shinhan.dongibuyeo.domain.challenge.mapper.ChallengeMapper;
 import com.shinhan.dongibuyeo.domain.challenge.repository.ChallengeRepository;
 import com.shinhan.dongibuyeo.domain.challenge.repository.MemberChallengeRepository;
 import com.shinhan.dongibuyeo.domain.member.entity.Member;
+import com.shinhan.dongibuyeo.domain.member.exception.ChallengeAlreadyStartedException;
 import com.shinhan.dongibuyeo.domain.member.service.MemberService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -65,10 +70,10 @@ public class ChallengeService {
     }
 
     @Transactional
-    public void joinChallenge(JoinChallengeRequest request) {
+    public void joinChallenge(UUID challengeId, JoinChallengeRequest request) {
         // MemberChallenge 생성
         Member member = memberService.getMemberById(request.getMemberId());
-        Challenge challenge = findChallengeById(request.getChallengeId());
+        Challenge challenge = findChallengeById(challengeId);
 
         MemberChallenge memberChallenge = MemberChallenge.builder()
                 .member(member)
@@ -78,7 +83,27 @@ public class ChallengeService {
 
         memberChallengeRepository.save(memberChallenge);
         // 챌린지 정보 변경
-        challenge.addMember(memberChallenge, request.getDeposit());
+        challenge.addMember(memberChallenge);
     }
 
+    @Transactional
+    public void cancelJoinChallenge(UUID challengeId, UUID memberId) {
+        Challenge challenge = findChallengeById(challengeId);
+
+        // TODO: 챌린지 시작 이후엔 취소할 수 없음 -> 적금의 경우 분기처리
+        if (LocalDate.now().isAfter(challenge.getStartDate())) {
+            throw new ChallengeAlreadyStartedException(challengeId);
+        }
+
+        MemberChallenge memberChallenge = getMemberChallenge(challengeId, memberId);
+        challenge.removeMember(memberChallenge);
+        memberChallenge.softDelete();
+
+        // TODO: 보증금 반환 로직
+    }
+
+    private MemberChallenge getMemberChallenge(UUID challengeId, UUID memberId) {
+        return memberChallengeRepository.findMemberChallengeByChallengeIdAndMemberId(challengeId, memberId)
+                .orElseThrow(() -> new MemberChallengeNotFoundException(challengeId, memberId));
+    }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -1,14 +1,27 @@
 package com.shinhan.dongibuyeo.domain.challenge.service;
 
+import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
+import com.shinhan.dongibuyeo.domain.challenge.mapper.ChallengeMapper;
 import com.shinhan.dongibuyeo.domain.challenge.repository.ChallengeRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class ChallengeService {
 
     private final ChallengeRepository challengeRepository;
+    private final ChallengeMapper challengeMapper;
 
-    public ChallengeService(ChallengeRepository challengeRepository) {
+    public ChallengeService(ChallengeRepository challengeRepository, ChallengeMapper challengeMapper) {
         this.challengeRepository = challengeRepository;
+        this.challengeMapper = challengeMapper;
+    }
+
+    public List<ChallengeResponse> findAllChallenges() {
+        return challengeRepository.findAll()
+                .stream()
+                .map(challengeMapper::toChallengeResponse)
+                .toList();
     }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -172,6 +172,7 @@ public class ChallengeService {
         challenge.updateTitle(request.getTitle());
         challenge.updateDescription(request.getDescription());
         challenge.updateDate(request.getStartDate(), request.getEndDate());
+        challenge.updateImage(request.getImage());
 
         return challengeMapper.toChallengeResponse(challenge);
     }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -6,6 +6,7 @@ import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.MemberChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
+import com.shinhan.dongibuyeo.domain.challenge.entity.ChallengeStatus;
 import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
 import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeNotFoundException;
 import com.shinhan.dongibuyeo.domain.challenge.exception.MemberChallengeNotFoundException;
@@ -67,7 +68,7 @@ public class ChallengeService {
     @Transactional
     public ChallengeResponse makeChallenge(ChallengeRequest request) {
         // TODO: request의 계좌 ID 기반으로 계좌를 조회해 계좌 연결하는 로직까지 추가
-        Challenge challenge = challengeMapper.toChallenge(request);
+        Challenge challenge = challengeMapper.toChallengeEntity(request);
         challengeRepository.save(challenge);
         return challengeMapper.toChallengeResponse(challenge);
     }
@@ -133,5 +134,12 @@ public class ChallengeService {
         challenge.updateDate(request.getStartDate(), request.getEndDate());
 
         return challengeMapper.toChallengeResponse(challenge);
+    }
+
+    public List<ChallengeResponse> findAllChallengesByStatus(ChallengeStatus status) {
+        return challengeRepository.findChallengesByStatus(status)
+                .stream()
+                .map(challengeMapper::toChallengeResponse)
+                .toList();
     }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -3,6 +3,7 @@ package com.shinhan.dongibuyeo.domain.challenge.service;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
+import com.shinhan.dongibuyeo.domain.challenge.dto.response.MemberChallengeResponse;
 import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
 import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeNotFoundException;
@@ -19,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -115,4 +115,8 @@ public class ChallengeService {
                 .orElseThrow(() -> new MemberChallengeNotFoundException(challengeId, memberId));
     }
 
+    public MemberChallengeResponse findChallengeByChallengeIdAndMemberId(UUID challengeId, UUID memberId) {
+        return memberChallengeRepository.findChallengeByMemberIdAndChallengeId(challengeId, memberId)
+                .orElseThrow(() -> new MemberChallengeNotFoundException(challengeId, memberId));
+    }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -1,10 +1,14 @@
 package com.shinhan.dongibuyeo.domain.challenge.service;
 
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
+import com.shinhan.dongibuyeo.domain.challenge.entity.Challenge;
 import com.shinhan.dongibuyeo.domain.challenge.exception.ChallengeNotFoundException;
 import com.shinhan.dongibuyeo.domain.challenge.mapper.ChallengeMapper;
 import com.shinhan.dongibuyeo.domain.challenge.repository.ChallengeRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.UUID;
@@ -32,4 +36,21 @@ public class ChallengeService {
                 .map(challengeMapper::toChallengeResponse)
                 .orElseThrow(() -> new ChallengeNotFoundException(challengeId));
     }
+
+    @Transactional
+    public ChallengeResponse makeChallenge(ChallengeRequest request) {
+        // TODO: request의 계좌 ID 기반으로 계좌를 조회해 계좌 연결하는 로직까지 추가
+        Challenge challenge = challengeMapper.toChallenge(request);
+        challengeRepository.save(challenge);
+        return challengeMapper.toChallengeResponse(challenge);
+    }
+
+    @Transactional
+    public void joinChallenge(JoinChallengeRequest request) {
+        // MemberChallenge 생성
+
+        //
+    }
+
+
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -130,8 +130,7 @@ public class ChallengeService {
         challenge.updateChallengeType(request.getType());
         challenge.updateTitle(request.getTitle());
         challenge.updateDescription(request.getDescription());
-        challenge.updateStartDate(request.getStartDate());
-        challenge.updateEndDate(request.getEndDate());
+        challenge.updateDate(request.getStartDate(), request.getEndDate());
 
         return challengeMapper.toChallengeResponse(challenge);
     }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -1,5 +1,6 @@
 package com.shinhan.dongibuyeo.domain.challenge.service;
 
+import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeModifyRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.ChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.request.JoinChallengeRequest;
 import com.shinhan.dongibuyeo.domain.challenge.dto.response.ChallengeResponse;
@@ -118,5 +119,18 @@ public class ChallengeService {
     public MemberChallengeResponse findChallengeByChallengeIdAndMemberId(UUID challengeId, UUID memberId) {
         return memberChallengeRepository.findChallengeByMemberIdAndChallengeId(challengeId, memberId)
                 .orElseThrow(() -> new MemberChallengeNotFoundException(challengeId, memberId));
+    }
+
+    @Transactional
+    public ChallengeResponse updateChallengeByChallengeId(UUID challengeId, ChallengeModifyRequest request) {
+        Challenge challenge = findChallengeById(challengeId);
+
+        challenge.updateChallengeType(request.getType());
+        challenge.updateTitle(request.getTitle());
+        challenge.updateDescription(request.getDescription());
+        challenge.updateStartDate(request.getStartDate());
+        challenge.updateEndDate(request.getEndDate());
+
+        return challengeMapper.toChallengeResponse(challenge);
     }
 }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/challenge/service/ChallengeService.java
@@ -134,7 +134,7 @@ public class ChallengeService {
         MemberChallenge memberChallenge = getMemberChallenge(challengeId, memberId);
 
         // 적금의 경우만 중도 해지 가능
-        if(challenge.getType() != ChallengeType.SAVINGS) {
+        if(challenge.getType() != ChallengeType.SAVINGS_SEVEN) {
             throw new ChallengeCannotWithdrawException(challenge.getType());
         }
 

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/controller/MemberController.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/controller/MemberController.java
@@ -55,7 +55,7 @@ public class MemberController {
 
     @GetMapping
     public ResponseEntity<List<MemberResponse>> getAllMembers() {
-        return ResponseEntity.ok(memberService.findMembers());
+        return ResponseEntity.ok(memberService.findAllMembers());
     }
 
     @GetMapping("/{memberId}")

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/entity/Member.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/entity/Member.java
@@ -56,6 +56,14 @@ public class Member extends BaseEntity {
         this.deviceToken = deviceToken;
     }
 
+    public void addChallenge(MemberChallenge memberChallenge) {
+        myChallenges.add(memberChallenge);
+    }
+
+    public void removeChallenge(MemberChallenge memberChallenge) {
+        myChallenges.remove(memberChallenge);
+    }
+
     public void updateUserKey(String userKey) {
         this.userKey = userKey;
     }

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/entity/Member.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/entity/Member.java
@@ -36,7 +36,7 @@ public class Member extends BaseEntity {
 
     private String profileImage;
 
-    private String apiKey;
+    private String userKey;
 
     private String deviceToken;
 
@@ -52,8 +52,8 @@ public class Member extends BaseEntity {
         this.deviceToken = deviceToken;
     }
 
-    public void updateApiKey(String apiKey) {
-        this.apiKey = apiKey;
+    public void updateUserKey(String userKey) {
+        this.userKey = userKey;
     }
 
     public void updateDeviceToken(String deviceToken) {

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/entity/Member.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/entity/Member.java
@@ -1,11 +1,17 @@
 package com.shinhan.dongibuyeo.domain.member.entity;
 
 import com.github.f4b6a3.ulid.UlidCreator;
+import com.shinhan.dongibuyeo.domain.challenge.entity.MemberChallenge;
 import com.shinhan.dongibuyeo.global.entity.BaseEntity;
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
 import lombok.*;
 import org.hibernate.annotations.SQLRestriction;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
 @Entity
@@ -33,6 +39,9 @@ public class Member extends BaseEntity {
     private String apiKey;
 
     private String deviceToken;
+
+    @OneToMany(mappedBy = "member")
+    private List<MemberChallenge> myChallenges = new ArrayList<>();
 
     @Builder
     public Member(String email, String name, String nickname, String profileImage, String deviceToken) {

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/exception/ChallengeAlreadyStartedException.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/exception/ChallengeAlreadyStartedException.java
@@ -1,0 +1,18 @@
+package com.shinhan.dongibuyeo.domain.member.exception;
+
+import com.shinhan.dongibuyeo.global.exception.BaseException;
+
+import java.util.Map;
+import java.util.UUID;
+
+public class ChallengeAlreadyStartedException extends BaseException {
+
+    public ChallengeAlreadyStartedException(UUID challengeId) {
+        super(
+                "CHALLENGE_ALREADY_STARTED_01",
+                "이미 챌린지가 시작되어 취소할 수 없습니다.",
+                Map.of("challengeId", String.valueOf(challengeId))
+        );
+    }
+
+}

--- a/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/service/MemberService.java
+++ b/dongibuyeo/src/main/java/com/shinhan/dongibuyeo/domain/member/service/MemberService.java
@@ -97,7 +97,7 @@ public class MemberService {
         member.changeProfileImage(request.getProfileImage());
     }
 
-    public List<MemberResponse> findMembers() {
+    public List<MemberResponse> findAllMembers() {
         return memberRepository.findAll()
                 .stream()
                 .map(memberMapper::toMemberResponse)


### PR DESCRIPTION
## #️⃣연관된 이슈

> #10

## 📝작업 내용

> 챌린지 생성, 조회, 수정, 삭제 기능 
> 멤버의 챌린지 참여, 취소, 중도 해지 기능 

## 💬리뷰 요구사항

> 정산 API 완료 후 보완해야 합니다
